### PR TITLE
Usersの結合テストコードの実装

### DIFF
--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -15,7 +15,7 @@
 
           <div class="field">
             <%= f.label :password, "パスワード再入力" %><br />
-            <%= f.password_field :password, autocomplete: "new-password" %>
+            <%= f.password_field :password, autocomplete: "new-password", id: "password_confirmation" %>
           </div>
 
           <div class="field">

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.describe 'ユーザー新規登録', type: :system do
+  before do
+    @user = FactoryBot.build(:user)
+  end
+  context 'ユーザー新規登録ができるとき' do 
+    it '正しい情報を入力すればユーザー新規登録ができてトップページに移動する' do
+      # トップページに移動する
+      visit root_path
+      # トップページにサインアップページへ遷移するボタンがあることを確認する
+      expect(page).to have_content('新規登録')
+      # 新規登録ページへ移動する
+      visit new_user_registration_path
+      # ユーザー情報を入力する
+      fill_in 'メールアドレス', with: @user.email
+      fill_in 'user[password]',match: :first, with: @user.password
+      fill_in 'password_confirmation', with: @user.password
+      fill_in 'ユーザー名', with: @user.name
+      fill_in 'プロフィール', with: @user.profile
+      # サインアップボタンを押すとユーザーモデルのカウントが1上がることを確認する
+      expect{
+        find('input[name="commit"]').click
+      }.to change { User.count }.by(1)
+      # トップページへ遷移したことを確認する
+      expect(current_path).to eq(root_path)
+      # トップページにログアウトボタンが表示されることを確認する
+      expect(page).to have_content('ログアウト')
+      # サインアップページへ遷移するボタンや、ログインページへ遷移するボタンが表示されていないことを確認する
+      expect(page).to have_no_content('新規登録')
+      expect(page).to have_no_content('ログイン')
+    end
+  end
+  context 'ユーザー新規登録ができないとき' do
+    it '誤った情報ではユーザー新規登録ができずに新規登録ページへ戻ってくる' do
+      # トップページに移動する
+      # トップページにサインアップページへ遷移するボタンがあることを確認する
+      # 新規登録ページへ移動する
+      # ユーザー情報を入力する
+      # サインアップボタンを押してもユーザーモデルのカウントは上がらないことを確認する
+      # 新規登録ページへ戻されることを確認する
+    end
+  end
+end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -31,14 +31,27 @@ RSpec.describe 'ユーザー新規登録', type: :system do
       expect(page).to have_no_content('ログイン')
     end
   end
+
   context 'ユーザー新規登録ができないとき' do
     it '誤った情報ではユーザー新規登録ができずに新規登録ページへ戻ってくる' do
       # トップページに移動する
+      visit root_path
       # トップページにサインアップページへ遷移するボタンがあることを確認する
+      expect(page).to have_content('新規登録')
       # 新規登録ページへ移動する
+      visit new_user_registration_path
       # ユーザー情報を入力する
+      fill_in 'メールアドレス', with: ''
+      fill_in 'user[password]',match: :first, with: ''
+      fill_in 'password_confirmation', with: ''
+      fill_in 'ユーザー名', with: ''
+      fill_in 'プロフィール', with: ''
       # サインアップボタンを押してもユーザーモデルのカウントは上がらないことを確認する
+      expect{
+        find('input[name="commit"]').click
+      }.to change { User.count }.by(0)
       # 新規登録ページへ戻されることを確認する
+      expect(current_path).to eq user_registration_path
     end
   end
 end


### PR DESCRIPTION
#What
・usersの結合テストコードの実装

#Why
・ユーザーがたどる一連の流れを確認するため